### PR TITLE
Fix "Set Minimum Grid Division Pixels to 0" with SWS 2.11

### DIFF
--- a/Lua/Tools/CS_Set Minimum Grid Division Pixels to 0.lua
+++ b/Lua/Tools/CS_Set Minimum Grid Division Pixels to 0.lua
@@ -1,14 +1,13 @@
 --[[
-@description CS_Set Minimum Grid Division Pixels to 0
-@version 1.0
+@description Set Minimum Grid Division Pixels to 0
+@version 1.0.1
 @author Claudiohbsantos
 @link http://claudiohbsantos.com
 @date 2018 03 09
 @about
   # CS_Set Minimum Grid Division Pixels to 0
   Set's the minimum grid division to 0. 
-@changelog
-  - initial release
+@changelog fix behavior with SWS 2.11
 --]]
 
-reaper.SNM_SetDoubleConfigVar("projgridmin",0)
+reaper.SNM_SetIntConfigVar("projgridmin", 0)


### PR DESCRIPTION
`"projgridmin"` is an integer value so `SNM_SetIntConfigVar` must be used. SWS 2.11 added checks to prevent invalid data interpretation (reaper-oss/sws#1131). `SNM_SetDoubleConfigVar` now does nothing (and returns false) for non-double values.

Originally reported here: https://forum.cockos.com/showthread.php?t=229235.